### PR TITLE
fix: ignore assets without resources

### DIFF
--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -68,6 +68,16 @@ Object {
 }
 `;
 
+exports[`ignore assets without resources 1`] = `
+Object {
+  "Parameters": Object {
+    "Param": Object {
+      "Type": "String",
+    },
+  },
+}
+`;
+
 exports[`multiple resources 1`] = `
 Object {
   "Resources": Object {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { Stack } from "@aws-cdk/core";
+import { CfnParameter, Stack } from "@aws-cdk/core";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Topic } from "@aws-cdk/aws-sns";
 import { Code, Function, Runtime } from "@aws-cdk/aws-lambda";
@@ -82,6 +82,16 @@ test("ignore assets", () => {
     runtime: Runtime.NODEJS_12_X,
     handler: "index.handler",
   });
+
+  expect(stack).toMatchCdkSnapshot({
+    ignoreAssets: true,
+  });
+});
+
+test("ignore assets without resources", () => {
+  const stack = new Stack();
+
+  new CfnParameter(stack, "Param")
 
   expect(stack).toMatchCdkSnapshot({
     ignoreAssets: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ const convertStack = (stack: Stack, options: Options = {}) => {
 
   const template = SynthUtils.toCloudFormation(stack, synthOptions);
 
-  if (ignoreAssets && template.Parameters) {
+  if (ignoreAssets && template.Parameters && template.Resources) {
     template.Parameters = expect.any(Object);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This fixes an edge case where a stack holds no resources
and we have enabled ignoreAssets.

Error before this fix:

  TypeError: Cannot convert undefined or null to object
      at Function.values (<anonymous>)

As far as I know we will not have any asset details without
also having a resource using it.