### PR TITLE
CDK v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["10", "12"]
+        node: ["14", "16"]
     name: Node ${{ matrix.node }} build
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -31,21 +31,20 @@
     "js-yaml": "^3.13.1"
   },
   "peerDependencies": {
-    "@aws-cdk/assert": ">=1.15.0",
-    "@aws-cdk/core": ">=1.0.0",
+    "@aws-cdk/assert": ">=2.0.0",
+    "aws-cdk-lib": ">=2.0.0",
+    "constructs": ">=10.0.0",
     "jest": ">=24.8.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.58.0",
-    "@aws-cdk/aws-lambda": "^1.58.0",
-    "@aws-cdk/aws-s3": "^1.58.0",
-    "@aws-cdk/aws-sns": "^1.58.0",
-    "@aws-cdk/core": "^1.58.0",
+    "@aws-cdk/assert": "^2.0.0",
     "@types/jest": "^25.1.4",
     "@types/js-yaml": "^3.12.3",
     "@types/node": "^12.12.34",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.9",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -14,7 +14,6 @@ Object {
 
 exports[`ignore assets 1`] = `
 Object {
-  "Parameters": Any<Object>,
   "Resources": Object {
     "Function76856677": Object {
       "DependsOn": Array [

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,9 +1,8 @@
+import { CfnParameter, Stack } from "aws-cdk-lib";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Topic } from "aws-cdk-lib/aws-sns";
 import * as path from "path";
-import { CfnParameter, Stack } from "@aws-cdk/core";
-import { Bucket } from "@aws-cdk/aws-s3";
-import { Topic } from "@aws-cdk/aws-sns";
-import { Code, Function, Runtime } from "@aws-cdk/aws-lambda";
-
 import "../index";
 
 test("default setup", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,10 @@ const convertStack = (stack: Stack, options: Options = {}) => {
 
   const template = SynthUtils.toCloudFormation(stack, synthOptions);
 
-  if (ignoreAssets && template.Parameters && template.Resources) {
-    template.Parameters = expect.any(Object);
+  if (ignoreAssets && template.Resources) {
+    if (template.Parameters) {
+      template.Parameters = expect.any(Object);
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Object.values(template.Resources).forEach((resource: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { SynthUtils } from "@aws-cdk/assert";
-import { Stack, SynthesisOptions } from "@aws-cdk/core";
+import { Stack, StageSynthesisOptions } from "aws-cdk-lib";
 import { toMatchSnapshot } from "jest-snapshot";
 import * as jsYaml from "js-yaml";
 
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-type Options = SynthesisOptions & {
+type Options = StageSynthesisOptions & {
   /**
    * Output snapshots in YAML (instead of JSON)
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,258 +2,33 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.58.0.tgz#2dc777d0b558df6f338a4e8dafeeb43702650aad"
-  integrity sha512-otuTRvyFUhxipA/Zw+S6HIewLsm4W9dyavXZlTULLJVUQpTfY+uScPB0R6ajJfkO3fFrOTZP4LglRGmm7e4zsg==
+"@aws-cdk/assert@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-2.0.0.tgz#0d56ad16fe8050fde86c6f8bbbf624b23ad105c7"
+  integrity sha512-fqhBlQ2+D4573104DD67y3eC43xc68trOMHrp0KC8iHFt8Bwxyh5yPwSJt1TQzzha4hNnRarXVVzEBxhbN+gkA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.58.0"
-    "@aws-cdk/cloudformation-diff" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    constructs "^3.0.2"
+    "@aws-cdk/cloudformation-diff" "2.0.0"
 
-"@aws-cdk/assets@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.58.0.tgz#a0d38aa15f978ed18d4a013a521a3139dac040d8"
-  integrity sha512-tycOCYRYNkG5Xem1FeNgk8h1kXEjrh9wzQ4hfj9KDn058DATb+H9hceUDj8lu/sdn0UeacWsPR/+m1mkNnlXMQ==
+"@aws-cdk/cfnspec@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-2.0.0.tgz#97ae64488d2bd6629451c521e4c7f7e9b58e97e7"
+  integrity sha512-l04CkW6E7AEkuAe5zza7J0WNKfpArFMg/fZx0bbgpvfZBNs4WSkGwuo0byKT2Sn4Xv/sYirKSJNkQ5Jikt17+Q==
   dependencies:
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    constructs "^3.0.2"
+    fs-extra "^9.1.0"
+    md5 "^2.3.0"
 
-"@aws-cdk/aws-applicationautoscaling@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.58.0.tgz#0e680d22e47f2ca63208c8da1c7909ade07e256a"
-  integrity sha512-TTcwbF7hxIjSH+1jSetk5vBJFrKbRKp6Umr8+jfQqtLWnfTL4xOaL8KOUSfKrqIs4O8sgNaZq5ajqXsHARlI3g==
+"@aws-cdk/cloudformation-diff@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.0.0.tgz#b7b525bfd7b776c5de596ed9341f04c1d4d2f56c"
+  integrity sha512-dJU9NyBdriaHzwE91S6rZOaV+FGs/+v6ZS9pAQ518d4Fn5kskIQJh2aUICwVAFOeyYNoSn5xbMxLDclDczXYSA==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.58.0"
-    "@aws-cdk/aws-cloudwatch" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-autoscaling-common@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.58.0.tgz#1eaad6f22d47e1d566873f32d26d4b60bb38964c"
-  integrity sha512-HBYoaZFqnEXGooxWI7w3puk9PlmrpCtXK6mL8bycA+9B3nvxaADLO2q54me9lhlIO7jVE1D6UsIyc75H48NOEw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-cloudwatch@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.58.0.tgz#e4538e1e3a8a7ec07cb5938dd033f15a08f6fab8"
-  integrity sha512-tbK+nc5F+QvBHzetL6KoaWVVIfmTEPeV6pLJlyCnT1FV3C91hU8RIOdKLfPMh9yxpbxjy4gmZFEfzqgXjb++aA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-codeguruprofiler@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.58.0.tgz#0fd4bf13b2eda6c4346034d3e765af532063b615"
-  integrity sha512-UlJ1BKXjKmKJc5nwV1ePJuzZk60s03R9+HtLg64RjbnIkuQC0No2fNoIxfMkcvcfx64FltVgh9sl8+dn2K0gxA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-
-"@aws-cdk/aws-ec2@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.58.0.tgz#a86ab85c971c2e83a060161b62ab426960abfa30"
-  integrity sha512-KbvV3/maBmFdapDHXfAbr7Wkx+VF0IWdsSwoWfHTEThvIPQNh7P22PZ1IoAC8mops0paRX2cUv0Ndf+gWgrH6w==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/aws-logs" "1.58.0"
-    "@aws-cdk/aws-s3" "1.58.0"
-    "@aws-cdk/aws-ssm" "1.58.0"
-    "@aws-cdk/cloud-assembly-schema" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    "@aws-cdk/region-info" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-efs@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.58.0.tgz#b8e2b5a5abeaf3d49b835c71ee860cd8cc7da44c"
-  integrity sha512-MoZ/lN1N7AdC5UoJ6yYCBcJLFQd9lqwv50OA4/TuRLdZh1yCneMiTw2Njr323pB9rzqAlKM16wuE3c1IL45Egw==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/cloud-assembly-schema" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-events@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.58.0.tgz#97cf18393e397833832cca4b85402fc49aa8ea4c"
-  integrity sha512-U+Km4D/BuQuF/SCzDJiA6+92rbiEoTR5cWbkn03cL4dy26db1kTugLwhfTvr66JKIAc8RW09w30rS5qL6arivA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-iam@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.58.0.tgz#61233b78eda7c9af40130ab057b81d55a919c153"
-  integrity sha512-hY/HtvWjkt6N1y5ZmcnzGKgcUjPqwJ2oO3l5di11HHVRmZhkbhM1tuI4LMNMVs1bUyZGjQApHt0+Qwyjzx2JuQ==
-  dependencies:
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/region-info" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-kms@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.58.0.tgz#581d1f966d5aecaa0983bf5e1274c3d4b4453aae"
-  integrity sha512-2scgHAqI5KX6JWmvlTf2oJZ1WQQlIKBkCJmxJT0y525o0hkVLMB2xUCMqA/CsTFt8j/RJ1jp8LOHedux4vyJXw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-lambda@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.58.0.tgz#ac556f88524d5529713625e53a8085c81a533401"
-  integrity sha512-j9DcUd7+zvGHueIrsd5SPlBKKbbYD+2Efxwh4iKu9SP84YZBm25RiwtWlEVcAyEKE144zu4FyIuhPKaJxQ5/bQ==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.58.0"
-    "@aws-cdk/aws-cloudwatch" "1.58.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.58.0"
-    "@aws-cdk/aws-ec2" "1.58.0"
-    "@aws-cdk/aws-efs" "1.58.0"
-    "@aws-cdk/aws-events" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-logs" "1.58.0"
-    "@aws-cdk/aws-s3" "1.58.0"
-    "@aws-cdk/aws-s3-assets" "1.58.0"
-    "@aws-cdk/aws-sqs" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-logs@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.58.0.tgz#0229d6005ac1758e118eabd09a1b0f4436d6ad10"
-  integrity sha512-el18uIhK5t4bOtETvWvCfJU/yh3aTJscsN2nhHe0EiQ0L3TViwDUnKxwLHK+Eh+VHGjAQFUbidR0ygf+3q9I8Q==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-s3-assets@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.58.0.tgz#8ac6482171ae7dbd34e146d6bcdbbbbe309168d1"
-  integrity sha512-A+hfFxIq98deOVRCPlNB8eWx4OhNkcISozS9PlEJsK2OMWEJEbhCFINI19wMjPkrYdcDCSMI0kuBf6AxAXQDdA==
-  dependencies:
-    "@aws-cdk/assets" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/aws-s3" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-s3@1.58.0", "@aws-cdk/aws-s3@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.58.0.tgz#5b7fbbb7190bb220fb0bfef7becfe7f9bbb3a06e"
-  integrity sha512-SrLctJLMUysik2olk6uoj7s5ND5DKiFYitSRpqLHheQMgfHp1KrLHz/hpCEn4V8stqnDjTkyi9W1T36YO8z0sw==
-  dependencies:
-    "@aws-cdk/aws-events" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-sns@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.58.0.tgz#75df70fe74606f7f4ed28f95872d3427192ca1f5"
-  integrity sha512-4RDp8a95gh6gpz/F4batG2i2xCldDyjs38RlDyB4DC0ssT16g2AcBIZq1OCj2oy26kB9oJQSUDmV5aHfng9m6Q==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.58.0"
-    "@aws-cdk/aws-events" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/aws-sqs" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-sqs@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.58.0.tgz#c0d9a5d1cd78b98b59be396c89112b78ef6c69e3"
-  integrity sha512-1MSnwMcCm336FnXzvQyEl46TFLuhduT+9FaTq+7skKq7q/SIPrHj5iB36cjAm4nuoUhP37uWFePQTXDjNhsyAA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.58.0"
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/aws-ssm@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.58.0.tgz#64905d3ed861f2c10b124473b4a6a8bd0f4137cc"
-  integrity sha512-z3pXuofqTevMl2r7AuSO83j2CP2Fvsqw4dw7yspk9qQMbVm9jA6XkyfA9n0rgqalr+5MDtLJE1VXDhMiHLQ0dQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.58.0"
-    "@aws-cdk/aws-kms" "1.58.0"
-    "@aws-cdk/cloud-assembly-schema" "1.58.0"
-    "@aws-cdk/core" "1.58.0"
-    constructs "^3.0.2"
-
-"@aws-cdk/cfnspec@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.58.0.tgz#11390f70f9ff81d6881e1d06e8aabae5bccbf66e"
-  integrity sha512-ChOJagv2mhvcYXsjUJUC+8//Upzv+ZU1UjH/B2k0Izgkghq+CB2yCcjYQGr/KgRygTvsDRVKXiGjKBBl0kcSKQ==
-  dependencies:
-    md5 "^2.2.1"
-
-"@aws-cdk/cloud-assembly-schema@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.58.0.tgz#c56a8b72703586bddba50a97ef60b0ce6b3a3ebe"
-  integrity sha512-uihmnZL76Yq/PrOpGRV4CX0Y0OLnVQbXnNpR0WSHfLn1gbBxzJIDik0HIGOzOhA6JckhKivouJswbephuug0Ug==
-  dependencies:
-    jsonschema "^1.2.5"
-    semver "^7.2.2"
-
-"@aws-cdk/cloudformation-diff@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.58.0.tgz#4f6f20892753b084330ea44b1cbe982da7a7eaa6"
-  integrity sha512-Dp0ZgF00Qvm9hciWs7DABKP4Y4Jm87w6Bl6T6SFw8fAKU8krFdYBPcv6AOw7YQV4TPzm4pzHMsZamGGKzI/elA==
-  dependencies:
-    "@aws-cdk/cfnspec" "1.58.0"
+    "@aws-cdk/cfnspec" "2.0.0"
+    "@types/node" "^10.17.60"
     colors "^1.4.0"
-    diff "^4.0.2"
+    diff "^5.0.0"
     fast-deep-equal "^3.1.3"
-    string-width "^4.2.0"
-    table "^5.4.6"
-
-"@aws-cdk/core@1.58.0", "@aws-cdk/core@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.58.0.tgz#a568fc0b757e3120eaea1cf4e50fabec8423b09c"
-  integrity sha512-3omLo3fZABhumuPXpHj9Vq35MSbuZuWmtazLdnWZp7VAACR9wVxRYcdBu3hpetWRm4eXiwECx6cIfT5jtPMkIQ==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.58.0"
-    "@aws-cdk/cx-api" "1.58.0"
-    constructs "^3.0.2"
-    fs-extra "^9.0.1"
-    minimatch "^3.0.4"
-
-"@aws-cdk/cx-api@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.58.0.tgz#34310a7fbd848dd3cecc2cfa2187df856c653d2b"
-  integrity sha512-t1Q7fXtk8Ux/psz0zGXY9YZkJtPY7fGurMkrAwoLGpM3GCmBR+jRBYqSHG1Rtvle6H+JdVtd1Ocs/Odfaz3bYg==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.58.0"
-    semver "^7.2.2"
-
-"@aws-cdk/region-info@1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.58.0.tgz#5caefd4aa8f1b021f64e29051869bc6bbe15948b"
-  integrity sha512-PAkoyPu4uxGEVTKYb1Tea6A0GoAfvC09iLfoIujHFNx38IdfrHm3X9Pn1995HvFJBuzLx1hv5AcGXOFVmwb8hg==
+    string-width "^4.2.3"
+    table "^6.7.3"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
@@ -510,6 +285,11 @@
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
+
+"@balena/dockerignore@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@balena/dockerignore/-/dockerignore-1.0.2.tgz#9ffe4726915251e8eb69f44ef3547e0da2c03e0d"
+  integrity sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -808,6 +588,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
+"@types/node@^10.17.60":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+
 "@types/node@^12.12.34":
   version "12.12.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.54.tgz#a4b58d8df3a4677b6c08bfbc94b7ad7a7a5f82d1"
@@ -943,6 +728,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -964,6 +759,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1050,6 +850,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1064,6 +869,21 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+aws-cdk-lib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.0.0.tgz#da7cf476363771f5ce4eb2aa73388b91db50553e"
+  integrity sha512-ETom3THcblmS3GSoS6rb2AGy7HZpcpoHvwNlxeVIVbmGOiKrrqjvECK2uOJtNboV/vDTHHjx/s/1SwptLo9dlg==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    case "1.6.3"
+    fs-extra "^9.1.0"
+    ignore "^5.1.9"
+    jsonschema "^1.4.0"
+    minimatch "^3.0.4"
+    punycode "^2.1.1"
+    semver "^7.3.5"
+    yaml "1.10.2"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1253,6 +1073,11 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
+case@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -1376,10 +1201,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-constructs@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.0.4.tgz#eb1ed5b80f6600b8d50de83971357ae0fe8e29a2"
-  integrity sha512-CDvg7gMjphE3DFX4pzkF6j73NREbR8npPFW8Mx/CLRnMR035+Y1o1HrXIsNSss/dq3ZUnNTU9jKyd3fL9EOlfw==
+constructs@^10.0.9:
+  version "10.0.9"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.9.tgz#fe724185e4288001850914e95cce2b32d848355f"
+  integrity sha512-C9la/fcnCKe3XIjKPbWuD49mnOYqSWdiMI6TNJmF0ao3pJw6Hap03Q4nsmCxpWMXuMzM546Kw/WnW7ElB3g4OA==
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
@@ -1527,10 +1352,10 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
-diff@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -1928,15 +1753,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
-  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
   dependencies:
     at-least-node "^1.0.0"
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
-    universalify "^1.0.0"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2136,6 +1961,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.9:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
 import-fresh@^3.0.0:
   version "3.2.1"
@@ -2826,6 +2656,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -2857,10 +2692,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonschema@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.6.tgz#52b0a8e9dc06bbae7295249d03e4b9faee8a0c0b"
-  integrity sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==
+jsonschema@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
+  integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -2944,6 +2779,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -2955,6 +2795,13 @@ lolex@^5.0.0:
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -2987,7 +2834,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-md5@^2.2.1:
+md5@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
@@ -3529,6 +3376,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -3646,10 +3498,17 @@ semver@6.x, semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.2.2, semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -3718,6 +3577,15 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3885,6 +3753,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
@@ -3898,6 +3775,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -3946,7 +3830,7 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-table@^5.2.3, table@^5.4.6:
+table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
   integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
@@ -3955,6 +3839,17 @@ table@^5.2.3, table@^5.4.6:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+table@^6.7.3:
+  version "6.7.5"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.7.5.tgz#f04478c351ef3d8c7904f0e8be90a1b62417d238"
+  integrity sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -4150,6 +4045,11 @@ universalify@^1.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
   integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -4334,6 +4234,16 @@ y18n@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@18.x, yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
v2 is GA as of today. https://aws.amazon.com/about-aws/whats-new/2021/12/aws-cloud-development-kit-cdk-generally-available/

This make the library target v2 of CDK instead of the current v1. The library should be bumped to 2.0.0 as a result of this.