### PR TITLE
feat: Ignore current version (revisit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ test('ignore assets', () => {
 
 ```
 
+## Ignore CurrentVersions
+
+With this enabled, hash-parts in Lambda's current version and in their references get masked.
+So the snapshot test will not fail if the hash changes.
+This is handy when you have concurrent pull requests that change hash.
+
+```typescript
+import * as path from 'path';
+import { Stack } from 'aws-cdk-lib';
+import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+
+test('ignore current version', () => {
+  const stack = new Stack();
+  
+  new Function(stack, 'Function', {
+    code: Code.fromAsset(path.join(__dirname, 'fixtures', 'lambda')),
+    runtime: Runtime.NODEJS_12_X,
+    handler: 'index.handler'
+  });
+
+  expect(stack).toMatchCdkSnapshot({
+      ignoreCurrentVersion: true,
+  });
+});
+```
+
 ## Use YAML as snapshot format
 
 ```typescript

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -77,6 +77,86 @@ Object {
 }
 `;
 
+exports[`ignore current version 1`] = `
+Object {
+  "Outputs": Object {
+    "CurrentVersion": Object {
+      "Value": Object {
+        "Ref": "FunctionCurrentVersion4E2B2261xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      },
+    },
+  },
+  "Resources": Object {
+    "Function76856677": Object {
+      "DependsOn": Array [
+        "FunctionServiceRole675BB04A",
+      ],
+      "Properties": Object {
+        "Code": Any<Object>,
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "FunctionServiceRole675BB04A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs12.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "FunctionCurrentVersion4E2B2261xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "Function76856677",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
+    },
+    "FunctionCurrentVersionInvokeAccountPrincipal1234567890125F843D1C": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Ref": "FunctionCurrentVersion4E2B2261xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        },
+        "Principal": "123456789012",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "FunctionServiceRole675BB04A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
 exports[`multiple resources 1`] = `
 Object {
   "Resources": Object {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,6 @@
-import { CfnParameter, Stack } from "aws-cdk-lib";
+import { CfnOutput, CfnParameter, Stack } from "aws-cdk-lib";
 import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { AccountPrincipal } from "aws-cdk-lib/aws-iam";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import * as path from "path";
@@ -94,5 +95,25 @@ test("ignore assets without resources", () => {
 
   expect(stack).toMatchCdkSnapshot({
     ignoreAssets: true,
+  });
+});
+
+test("ignore current version", () => {
+  const stack = new Stack();
+
+  const lf = new Function(stack, "Function", {
+    code: Code.fromAsset(path.join(__dirname, "fixtures", "lambda")),
+    runtime: Runtime.NODEJS_12_X,
+    handler: "index.handler",
+  });
+  lf.currentVersion.grantInvoke(new AccountPrincipal("123456789012"));
+
+  new CfnOutput(stack, "CurrentVersion", {
+    value: lf.currentVersion.functionArn,
+  });
+
+  expect(stack).toMatchCdkSnapshot({
+    ignoreAssets: true,
+    ignoreCurrentVersion: true,
   });
 });


### PR DESCRIPTION
Closes #11 

Supersedes https://github.com/hupe1980/jest-cdk-snapshot/pull/12
This PR is a revisit of #12 and #23

Sorry again, but after many months, I realize this is still very useful when multiple changes are made to CDK-using repos concurrently.

All references of the current version are also masked.
