### PR TITLE
fix: YAML should support ignoreAssets

### DIFF
--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`YAML should support ignoreAssets 1`] = `
+"Resources:
+  FunctionServiceRole675BB04A:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  Function76856677:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code: Any<Object>
+      Role:
+        'Fn::GetAtt':
+          - FunctionServiceRole675BB04A
+          - Arn
+      Handler: index.handler
+      Runtime: nodejs12.x
+    DependsOn:
+      - FunctionServiceRole675BB04A
+"
+`;
+
 exports[`default setup 1`] = `
 Object {
   "Resources": Object {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -96,3 +96,18 @@ test("ignore assets without resources", () => {
     ignoreAssets: true,
   });
 });
+
+test("YAML should support ignoreAssets", () => {
+  const stack = new Stack();
+
+  new Function(stack, "Function", {
+    code: Code.fromAsset(path.join(__dirname, "fixtures", "lambda")),
+    runtime: Runtime.NODEJS_12_X,
+    handler: "index.handler",
+  });
+
+  expect(stack).toMatchCdkSnapshot({
+    ignoreAssets: true,
+    yaml: true,
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,14 +63,16 @@ const convertStack = (stack: Stack, options: Options = {}) => {
   const template = SynthUtils.toCloudFormation(stack, synthOptions);
 
   if (ignoreAssets && template.Resources) {
+    const anyObject = yaml ? "Any<Object>" : expect.any(Object);
+
     if (template.Parameters) {
-      template.Parameters = expect.any(Object);
+      template.Parameters = anyObject;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Object.values(template.Resources).forEach((resource: any) => {
       if (resource?.Properties?.Code) {
-        resource.Properties.Code = expect.any(Object);
+        resource.Properties.Code = anyObject;
       }
     });
   }


### PR DESCRIPTION
Fixes #10 

`expect.any(Object)` is a Function instance, which YAML does not support.

After this PR, string literal `Any<Object>` is used.
