### PR TITLE
feat: Mask CurrentVersion everywhere

### DIFF
--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -144,7 +144,7 @@ exports[`ignore current version 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "FunctionCurrentVersion4E2B226151c1faf27d0d163dcd41fb04818fca79",
+            "FunctionCurrentVersion4E2B2261xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             "Version",
           ],
         },

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -137,6 +137,21 @@ exports[`ignore current version 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
+    "FunctionAliascurrentBA7922F5": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "Function76856677",
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionCurrentVersion4E2B226151c1faf27d0d163dcd41fb04818fca79",
+            "Version",
+          ],
+        },
+        "Name": "current",
+      },
+      "Type": "AWS::Lambda::Alias",
+    },
     "FunctionCurrentVersion4E2B2261xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": {
       "Properties": {
         "FunctionName": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -107,6 +107,7 @@ test("ignore current version", () => {
     handler: "index.handler",
   });
   lf.currentVersion.grantInvoke(new AccountPrincipal("123456789012"));
+  lf.addAlias("current", {});
 
   new CfnOutput(stack, "CurrentVersion", {
     value: lf.currentVersion.functionArn,

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,10 +80,17 @@ const maskCurrentVersionRefs = (tree: unknown): void => {
     }
   } else if (typeof tree === "object") {
     for (const [key, value] of Object.entries(tree)) {
-      if (key === "Ref" && typeof value === "string") {
-        const match = currentVersionRegex.exec(value);
-        if (match) {
-          tree[key] = `${match[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
+      const keyMatch = currentVersionRegex.exec(key);
+      if (keyMatch) {
+        const newKey = `${keyMatch[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
+        tree[newKey] = value;
+        delete tree[key];
+      }
+
+      if (typeof value === "string") {
+        const valueMatch = currentVersionRegex.exec(value);
+        if (valueMatch) {
+          tree[key] = `${valueMatch[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
         }
       } else if (typeof value === "object") {
         maskCurrentVersionRefs(value as Record<string, unknown>);
@@ -137,15 +144,6 @@ const convertStack = (stack: Stack, options: Options = {}) => {
   }
 
   if (ignoreCurrentVersion && template.Resources) {
-    for (const [key, resource] of Object.entries(template.Resources)) {
-      const match = currentVersionRegex.exec(key);
-      if (match) {
-        const newKey = `${match[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
-        template.Resources[newKey] = resource;
-        delete template.Resources[key];
-      }
-    }
-
     maskCurrentVersionRefs(template);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,15 +62,32 @@ export const toMatchCdkSnapshot = function (
   return propertyMatchers ? matcher(stack, propertyMatchers) : matcher(stack);
 };
 
-const maskCurrentVersionRefs = (tree: Record<string, unknown>): void => {
-  for (const [key, value] of Object.entries(tree)) {
-    if (key === "Ref" && typeof value === "string") {
-      const match = currentVersionRegex.exec(value);
-      if (match) {
-        tree[key] = `${match[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
+const maskCurrentVersionRefs = (tree: unknown): void => {
+  if (tree == null) {
+    return;
+  }
+  if (Array.isArray(tree)) {
+    for (let i = 0; i < tree.length; i++) {
+      const value = tree[i];
+      if (typeof value === "string") {
+        const match = currentVersionRegex.exec(value);
+        if (match) {
+          tree[i] = `${match[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
+        }
+      } else if (typeof value === "object") {
+        maskCurrentVersionRefs(value);
       }
-    } else if (typeof value === "object" && value !== null) {
-      maskCurrentVersionRefs(value as Record<string, unknown>);
+    }
+  } else if (typeof tree === "object") {
+    for (const [key, value] of Object.entries(tree)) {
+      if (key === "Ref" && typeof value === "string") {
+        const match = currentVersionRegex.exec(value);
+        if (match) {
+          tree[key] = `${match[1]}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`;
+        }
+      } else if (typeof value === "object") {
+        maskCurrentVersionRefs(value as Record<string, unknown>);
+      }
     }
   }
 };


### PR DESCRIPTION
Follow-up to #29 

Thanks for releasing v2.1.0 so quickly.
I tried it and found that CurrentVersion are not masked in Array.


In this PR, `maskCurrentVersionRefs` is more generalized 
- to also mask elements in Array
- to mask keys, not only in `template.Resources`, but all keys
- to mask values, not only `{ "Ref": "..."}`, but all values