### PR TITLE
fix: Snapshot is broken when toMatchCdkSnapshot is called over one of multiple stacks in a single app

### DIFF
--- a/src/__tests__/__snapshots__/stacks.test.ts.snap
+++ b/src/__tests__/__snapshots__/stacks.test.ts.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Multiple stacks in a single app dependent stacks 1`] = `
+{
+  "Resources": {
+    "BarA6AB415C": {
+      "DependsOn": [
+        "BarServiceRole3E5F94C9",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7ecc77636deefb31954ea2e6aadf6d2c361a2943535a678d65f46a8de5e1f503.zip",
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "BarServiceRole3E5F94C9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BarServiceRole3E5F94C9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
+exports[`Multiple stacks in a single app dependent stacks 2`] = `
+{
+  "Resources": {
+    "BarA6AB415C": {
+      "DependsOn": [
+        "BarServiceRole3E5F94C9",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7ecc77636deefb31954ea2e6aadf6d2c361a2943535a678d65f46a8de5e1f503.zip",
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "BarServiceRole3E5F94C9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BarServiceRole3E5F94C9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
+exports[`Multiple stacks in a single app one stack referencing the other 1`] = `
+{
+  "Outputs": {
+    "ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77": {
+      "Export": {
+        "Name": "S3:ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "FooDFE0DD70",
+          "Arn",
+        ],
+      },
+    },
+  },
+  "Resources": {
+    "FooDFE0DD70": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;
+
+exports[`Multiple stacks in a single app one stack referencing the other 2`] = `
+{
+  "Outputs": {
+    "ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77": {
+      "Export": {
+        "Name": "S3:ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "FooDFE0DD70",
+          "Arn",
+        ],
+      },
+    },
+  },
+  "Resources": {
+    "FooDFE0DD70": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/stacks.test.ts.snap
+++ b/src/__tests__/__snapshots__/stacks.test.ts.snap
@@ -3,58 +3,10 @@
 exports[`Multiple stacks in a single app dependent stacks 1`] = `
 {
   "Resources": {
-    "BarA6AB415C": {
-      "DependsOn": [
-        "BarServiceRole3E5F94C9",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "7ecc77636deefb31954ea2e6aadf6d2c361a2943535a678d65f46a8de5e1f503.zip",
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "BarServiceRole3E5F94C9",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "BarServiceRole3E5F94C9": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
+    "FooDFE0DD70": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }
@@ -147,24 +99,66 @@ exports[`Multiple stacks in a single app one stack referencing the other 1`] = `
 
 exports[`Multiple stacks in a single app one stack referencing the other 2`] = `
 {
-  "Outputs": {
-    "ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77": {
-      "Export": {
-        "Name": "S3:ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77",
+  "Resources": {
+    "BarA6AB415C": {
+      "DependsOn": [
+        "BarServiceRole3E5F94C9",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7ecc77636deefb31954ea2e6aadf6d2c361a2943535a678d65f46a8de5e1f503.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "bucket": {
+              "Fn::ImportValue": "S3:ExportsOutputFnGetAttFooDFE0DD70Arn2A3BEF77",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "BarServiceRole3E5F94C9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
       },
-      "Value": {
-        "Fn::GetAtt": [
-          "FooDFE0DD70",
-          "Arn",
+      "Type": "AWS::Lambda::Function",
+    },
+    "BarServiceRole3E5F94C9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
         ],
       },
-    },
-  },
-  "Resources": {
-    "FooDFE0DD70": {
-      "DeletionPolicy": "Retain",
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
+      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/src/__tests__/stacks.test.ts
+++ b/src/__tests__/stacks.test.ts
@@ -1,0 +1,42 @@
+import { Stack, App } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Function, Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import "../index";
+import path from "path";
+
+describe("Multiple stacks in a single app", () => {
+  test("dependent stacks", () => {
+    const app = new App();
+    const s3Stack = new Stack(app, "S3");
+    new Bucket(s3Stack, "Foo");
+
+    const lambdaStack = new Stack(app, "Lambda");
+    new Function(lambdaStack, "Bar", {
+      code: Code.fromAsset(path.join(__dirname, "fixtures", "lambda")),
+      handler: "index.handler",
+      runtime: Runtime.NODEJS_20_X,
+    });
+
+    expect(s3Stack).toMatchCdkSnapshot();
+    expect(lambdaStack).toMatchCdkSnapshot();
+  });
+
+  test("one stack referencing the other", () => {
+    const app = new App();
+    const s3Stack = new Stack(app, "S3");
+    const bucket = new Bucket(s3Stack, "Foo");
+
+    const lambdaStack = new Stack(app, "Lambda");
+    new Function(lambdaStack, "Bar", {
+      code: Code.fromAsset(path.join(__dirname, "fixtures", "lambda")),
+      handler: "index.handler",
+      runtime: Runtime.NODEJS_20_X,
+      environment: {
+        bucket: bucket.bucketArn,
+      },
+    });
+
+    expect(s3Stack).toMatchCdkSnapshot();
+    expect(lambdaStack).toMatchCdkSnapshot();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { App, Stack, StageSynthesisOptions } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Stack, StageSynthesisOptions } from "aws-cdk-lib";
 import { toMatchSnapshot } from "jest-snapshot";
 import * as jsYaml from "js-yaml";
 
@@ -12,6 +13,21 @@ declare global {
 }
 
 type Options = StageSynthesisOptions & {
+  /**
+   * @deprecated No effect. Please remove this, there is no alternative.
+   */
+  readonly skipValidation?: boolean;
+
+  /**
+   * @deprecated No effect. Please remove this, there is no alternative.
+   */
+  readonly validateOnSynthesis?: boolean;
+
+  /**
+   * @deprecated No effect. Please remove this, there is no alternative.
+   */
+  readonly force?: boolean;
+
   /**
    * Output snapshots in YAML (instead of JSON)
    */
@@ -110,7 +126,11 @@ const convertStack = (stack: Stack, options: Options = {}) => {
     ...synthOptions
   } = options;
 
-  const template = App.of(stack)?.synth(synthOptions).stacks[0].template ?? {};
+  if (Object.keys(synthOptions).length > 0) {
+    console.warn("Synth options are no longer supported. Please remove them.");
+  }
+
+  const template = Template.fromStack(stack, {}).toJSON();
 
   if (ignoreBootstrapVersion) {
     if (template.Parameters) {


### PR DESCRIPTION
I used v2.1.1 and found that my implementation in #29 generates broken snapshots, when `toMatchCdkSnapshot` is used on one of multiple stacks in one app.
It looks like that using `App.of(...).synth` is a culprit. 

I found the migration guide: https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/assertions/MIGRATING.md 
Using `Template.fromStack` appears to fix the issue.
I deprecated `StageSynthesisOptions` options since `Template.fromStack` does not support `StageSynthesisOptions`.


The first commit https://github.com/hupe1980/jest-cdk-snapshot/pull/33/commits/e7644897c0e583e5272b8f0241a57ec03a6f13e9 shows how it is broken:

- Two snapshots are identical and each contains the entire `App` snapshot
    - Snapshot `Multiple stacks in a single app dependent stacks 1`
    - Snapshot `Multiple stacks in a single app dependent stacks 2`
- Two snapshots are identical and each contains only `Outputs` and `S3::Bucket`, no `Lambda::Function` nor other resources.
    - Snapshot `Multiple stacks in a single app dependent stacks 1`
    - Snapshot `Multiple stacks in a single app dependent stacks 2`

The second commit https://github.com/hupe1980/jest-cdk-snapshot/pull/33/commits/f9542bf53c622b93b9f47112182925d7c2f93fd1 fixes that.
Now each first snapshot contains only `S3::Bucket`, and each second snapshot contains `Lambda::Function`
