### PR TITLE
docs: update ignoreBootstrapVersion doc block to default to true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ type Options = StageSynthesisOptions & {
 
   /**
    * Excludes CDK v2-managed bootstrap versions.
-   * Defaults to `false`.
+   * Defaults to `true`.
    */
   ignoreBootstrapVersion?: boolean;
 };


### PR DESCRIPTION
I noticed the default behaviour differs from the doc block, so a small PR to rectify this