### PR TITLE
Export Options type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-type Options = StageSynthesisOptions & {
+export type Options = StageSynthesisOptions & {
   /**
    * @deprecated No effect. Please remove this, there is no alternative.
    */


### PR DESCRIPTION
This pull request exports the type `Options` so that the type can be used in tests.

Background: I want to test multiple CDK Stacks in my project and I have written a wrapper to reduce duplication in my tests.

Here is my wrapper:

```
import { App, Stack } from 'aws-cdk-lib';
import { Environment } from '@/environment-data';
import 'jest-cdk-snapshot';
import { Options } from 'jest-cdk-snapshot';

export function testStackSnapshot(stackClass: typeof Stack, jestCdkSnapshotOptions?: Options) {
// I need Options here                                                               ^^^^^^^
  const app = new App();
  const stack = new stackClass(app, 'dummy-id', {
    env: {
      account: Environment.dev,
      region: 'eu-west-1',
    },
  });
  expect(stack).toMatchCdkSnapshot(jestCdkSnapshotOptions);
}
```

Here is a test example:

```
import { testStackSnapshot } from '@/tests/test-stack-snapshot';
import { FrontendStack } from '@/frontend/frontend-stack';

it('should match the saved snapshot', () => {
  testStackSnapshot(FrontendStack, {
    propertyMatchers: {
      Resources: {
        deploymonalisaCustomResourceC20061ED: {
          Properties: {
            SourceObjectKeys: expect.any(Array),
          },
        },
      },
    },
  });
});
```