### PR TITLE
feat: ignore metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,27 @@ test('propertyMatchers', () => {
 });
 ```
 
+## Ignore Metadata
+
+With this enabled CloudFormation metadata both on Stack and Resource level will be ignored.
+Metadata is often added by Aspects or other libraries.
+
+```typescript
+import { Stack } from 'aws-cdk-lib/core';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import 'jest-cdk-snapshot';
+
+test('default setup', () => {
+  const stack = new Stack();
+
+  new Bucket(stack, 'Foo');
+
+  expect(stack).toMatchCdkSnapshot({
+    ignoreMetadata: true,
+  });
+});
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -205,6 +205,18 @@ exports[`ignore current version 1`] = `
 }
 `;
 
+exports[`metadata should not be included if skipped 1`] = `
+{
+  "Resources": {
+    "FooDFE0DD70": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;
+
 exports[`multiple resources 1`] = `
 {
   "Resources": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export const toMatchCdkSnapshot = function (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   this: any,
   received: Stack,
-  options: Options = {}
+  options: Options = {},
 ) {
   const matcher = toMatchSnapshot.bind(this);
   const { propertyMatchers, ...convertOptions } = options;
@@ -212,6 +212,6 @@ if (expect !== undefined) {
   console.error(
     "Unable to find Jest's global expect." +
       "\nPlease check you have added jest-cdk-snapshot correctly." +
-      "\nSee https://github.com/hupe1980/jest-cdk-snapshot for help."
+      "\nSee https://github.com/hupe1980/jest-cdk-snapshot for help.",
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,11 @@ export type Options = StageSynthesisOptions & {
    * Defaults to `true`.
    */
   ignoreBootstrapVersion?: boolean;
+
+  /**
+   * Ignore Metadata
+   */
+  ignoreMetadata?: boolean;
 };
 
 const currentVersionRegex = /^(.+CurrentVersion[0-9A-F]{8})[0-9a-f]{32}$/;
@@ -68,7 +73,7 @@ export const toMatchCdkSnapshot = function (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   this: any,
   received: Stack,
-  options: Options = {},
+  options: Options = {}
 ) {
   const matcher = toMatchSnapshot.bind(this);
   const { propertyMatchers, ...convertOptions } = options;
@@ -121,6 +126,7 @@ const convertStack = (stack: Stack, options: Options = {}) => {
     ignoreAssets = false,
     ignoreBootstrapVersion = true,
     ignoreCurrentVersion = false,
+    ignoreMetadata = false,
     subsetResourceTypes,
     subsetResourceKeys,
     ...synthOptions
@@ -184,6 +190,19 @@ const convertStack = (stack: Stack, options: Options = {}) => {
     }
   }
 
+  if (ignoreMetadata && template.Metadata) {
+    delete template.Metadata;
+  }
+
+  if (ignoreMetadata && template.Resources) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Object.values(template.Resources).forEach((resource: any) => {
+      if (resource?.Metadata) {
+        delete resource.Metadata;
+      }
+    });
+  }
+
   return yaml ? jsYaml.safeDump(template) : template;
 };
 
@@ -193,6 +212,6 @@ if (expect !== undefined) {
   console.error(
     "Unable to find Jest's global expect." +
       "\nPlease check you have added jest-cdk-snapshot correctly." +
-      "\nSee https://github.com/hupe1980/jest-cdk-snapshot for help.",
+      "\nSee https://github.com/hupe1980/jest-cdk-snapshot for help."
   );
 }


### PR DESCRIPTION
Allows to ignore metadata, both on the stack level and also resource level.

Often libraries (like cdk-nag) or Aspects add additional metadata that is almost never relevant to be snapshotted.

cc @hupe1980 