### PR TITLE
feat: ignore resource tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ test('default setup', () => {
 });
 ```
 
+## Ignore Resource Tags
+
+With this enabled, tags on all resources that have tags configured are ignored.
+This can be useful in situations where tags contain changing informatione like the commit or a pipeline id.
+
+```typescript
+  expect(stack).toMatchCdkSnapshot({
+    ignoreTags: true,
+  });
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -314,6 +314,19 @@ exports[`subsetResourceTypes 1`] = `
 }
 `;
 
+exports[`tags should not be included if skipped 1`] = `
+{
+  "Resources": {
+    "FooDFE0DD70": {
+      "DeletionPolicy": "Retain",
+      "Properties": {},
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;
+
 exports[`yaml setup 1`] = `
 "Resources:
   FooDFE0DD70:

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import {
   CfnResource,
   IAspect,
   Stack,
+  Tags,
 } from "aws-cdk-lib";
 import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
 import { AccountPrincipal } from "aws-cdk-lib/aws-iam";
@@ -179,5 +180,16 @@ test("metadata should not be included if skipped", () => {
 
   expect(stack).toMatchCdkSnapshot({
     ignoreMetadata: true,
+  });
+});
+
+test("tags should not be included if skipped", () => {
+  const stack = new Stack();
+  const bucket = new Bucket(stack, "Foo");
+
+  Tags.of(bucket).add("dummy", "test");
+
+  expect(stack).toMatchCdkSnapshot({
+    ignoreTags: true,
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,11 @@ export type Options = StageSynthesisOptions & {
    * Ignore Metadata
    */
   ignoreMetadata?: boolean;
+
+  /**
+   * Ignore Tags on resources
+   */
+  ignoreTags?: boolean;
 };
 
 const currentVersionRegex = /^(.+CurrentVersion[0-9A-F]{8})[0-9a-f]{32}$/;
@@ -127,6 +132,7 @@ const convertStack = (stack: Stack, options: Options = {}) => {
     ignoreBootstrapVersion = true,
     ignoreCurrentVersion = false,
     ignoreMetadata = false,
+    ignoreTags = false,
     subsetResourceTypes,
     subsetResourceKeys,
     ...synthOptions
@@ -199,6 +205,15 @@ const convertStack = (stack: Stack, options: Options = {}) => {
     Object.values(template.Resources).forEach((resource: any) => {
       if (resource?.Metadata) {
         delete resource.Metadata;
+      }
+    });
+  }
+
+  if (ignoreTags && template.Resources) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Object.values(template.Resources).forEach((resource: any) => {
+      if (resource?.Properties?.Tags) {
+        delete resource.Properties.Tags;
       }
     });
   }


### PR DESCRIPTION
With this enabled, tags on all resources that have tags configured are ignored.
This can be useful in situations where tags contain changing information like the commit or a pipeline id.

cc @hupe1980 