### PR TITLE
feat: ignore image definitions for containers when assets are ignored

### DIFF
--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -100,6 +100,130 @@ exports[`ignore assets 1`] = `
 }
 `;
 
+exports[`ignore assets including container images 1`] = `
+{
+  "Resources": {
+    "TaskDefinitionB36D86D9": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": Any<Object>,
+            "Name": "Container",
+          },
+        ],
+        "Cpu": "2048",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
+        "Family": "TaskDefinition",
+        "Memory": "6144",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "TaskDefinitionTaskRoleFD40A61D",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecr:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":repository/",
+                    {
+                      "Fn::Sub": "cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": [
+          {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TaskDefinitionTaskRoleFD40A61D": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
 exports[`ignore assets without resources 1`] = `
 {
   "Parameters": {

--- a/src/__tests__/fixtures/docker/Dockerfile
+++ b/src/__tests__/fixtures/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import * as path from "path";
 import "../index";
+import { ContainerImage, FargateTaskDefinition } from "aws-cdk-lib/aws-ecs";
 
 test("default setup", () => {
   const stack = new Stack();
@@ -100,6 +101,26 @@ test("ignore assets without resources", () => {
   const stack = new Stack();
 
   new CfnParameter(stack, "Param");
+
+  expect(stack).toMatchCdkSnapshot({
+    ignoreAssets: true,
+  });
+});
+
+test("ignore assets including container images", () => {
+  const stack = new Stack();
+
+  const taskDefinition = new FargateTaskDefinition(stack, "TaskDefinition", {
+    cpu: 2048,
+    memoryLimitMiB: 6144,
+  });
+
+  taskDefinition.addContainer("Container", {
+    image: ContainerImage.fromAsset(
+      path.join(__dirname, "fixtures", "docker"),
+      {},
+    ),
+  });
 
   expect(stack).toMatchCdkSnapshot({
     ignoreAssets: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,7 @@ const convertStack = (stack: Stack, options: Options = {}) => {
 
       if (resource?.Properties?.ContainerDefinitions) {
         resource?.Properties?.ContainerDefinitions.forEach(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (definition: any) => {
             definition.Image = anyObject;
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,14 @@ const convertStack = (stack: Stack, options: Options = {}) => {
       if (resource?.Properties?.Code) {
         resource.Properties.Code = anyObject;
       }
+
+      if (resource?.Properties?.ContainerDefinitions) {
+        resource?.Properties?.ContainerDefinitions.forEach(
+          (definition: any) => {
+            definition.Image = anyObject;
+          },
+        );
+      }
     });
   }
 


### PR DESCRIPTION
Also skip the container image definition in Task Definitions.
This is enabled with `ignoreAssets`. Let me know of you want it behind its own flag.

@hupe1980 Hopefully the last one for now :) 